### PR TITLE
added func-test boot task

### DIFF
--- a/clojure/build.boot
+++ b/clojure/build.boot
@@ -32,15 +32,21 @@
                    [tolitius/boot-check]]))))
 
 (set-env!
+  :resource-paths #{"src"}
   :source-paths #{"test" "resources"})
 
 (require
   '[adzerk.boot-test :refer [test]]
+  '[sixsq.slipstream.func-tests :refer [func-test]]
   '[adzerk.boot-reload :refer [reload]]
   '[tolitius.boot-check :refer [with-yagni with-eastwood with-kibit with-bikeshed]])
+
+(def test-opts {:exclusions '#{sixsq.slipstream.test-base}
+                :junit-output-to ""})
 
 (task-options!
   pom {:project (get-env :project)
        :version (get-env :version)}
-  test {:exclusions '#{sixsq.slipstream.test-base}
-        :junit-output-to ""})
+  test test-opts
+  func-test test-opts)
+

--- a/clojure/src/sixsq/slipstream/func_tests.clj
+++ b/clojure/src/sixsq/slipstream/func_tests.clj
@@ -1,0 +1,68 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns sixsq.slipstream.func-tests
+  (:require [boot.core :as boot]
+            [sixsq.slipstream.func-tests-impl :as ft]
+            [adzerk.boot-test :as btest]))
+
+(boot/deftask func-test
+  "SlipStream functional tests.
+
+  Before running boot test task, writes configuration file for the tests.
+
+  After tests are ran, the test results (XML) are copied to 'results-dir' (or
+  current directory).  If 'connector' is give, the test results are copied to
+  the directory under 'connector' sub-directory in 'results-dir'.
+
+  For connector specific tests (i.e. when 'connector' is provided) the metadata 
+  of the test suites in the test result files are renamed by prepending 'connector'
+  to the 'package' and 'classname' attributes.
+  "
+  [; func-test-pre
+   s endpoint ENDPOINT str "SlipStream endpoint."
+   u username USERNAME str "SlipStream username."
+   p password PASSWORD str "SlipStream password."
+   _ app-uri APPURI str "Application URI (for deploying app and scaling)."
+   _ comp-name COMPNAME str "Component name (for scalable tests)."
+   _ comp-uri COMPURI str "Component URI (for deploying component)."
+   c connectors CONNECTORS #{str} "Set of connector names."
+   ; boot/test
+   n namespaces NAMESPACE #{sym} "The set of namespace symbols to run tests in."
+   e exclusions NAMESPACE #{sym} "The set of namespace symbols to be excluded from test."
+   f filters    EXPR      #{edn} "The set of expressions to use to filter namespaces."
+   r requires   REQUIRES  #{sym} "Extra namespaces to pre-load into the pool of test pods for speed."
+   j junit-output-to JUNITOUT str "The directory where a junit formatted report will be generated for each ns"
+   ; func-test-post
+   d results-dir RESULTSDIR str "Directory where to copy the test results to."]
+  (let [tasks (mapcat identity
+                (for [c connectors]
+                  (conj []
+                        (ft/func-test-pre :serviceurl endpoint
+                                          :username username
+                                          :password password
+                                          :app-uri app-uri
+                                          :comp-name comp-name
+                                          :comp-uri comp-uri
+                                          :connector-name c)
+                        (btest/test :namespaces namespaces
+                                    :exclusions exclusions
+                                    :filters filters
+                                    :requires requires
+                                    :junit-output-to junit-output-to)
+                        (ft/func-test-post :results-dir (ft/results-loc results-dir c)
+                                           :connector-name c
+                                           :junit-output-to junit-output-to))))]
+    (apply comp tasks)))
+

--- a/clojure/src/sixsq/slipstream/func_tests_impl.clj
+++ b/clojure/src/sixsq/slipstream/func_tests_impl.clj
@@ -104,7 +104,7 @@
   (loop [loc zipper]
     (if (zip/end? loc)
       (zip/root loc)
-      (if-let [matcher-result (matcher loc)]
+      (if (matcher loc)
         (let [new-loc (zip/edit loc editor)]
           (if (not (= (zip/node new-loc) (zip/node loc)))
             (recur (zip/next new-loc))))

--- a/clojure/src/sixsq/slipstream/func_tests_impl.clj
+++ b/clojure/src/sixsq/slipstream/func_tests_impl.clj
@@ -1,0 +1,159 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+(ns sixsq.slipstream.func-tests-impl
+  (:require
+    [boot.core :as boot]
+    [clojure.java.io :as io]
+    [clojure.string :as s]
+    [clojure.pprint :refer [pprint]]
+    [clojure.zip :as zip]
+    [clojure.data.xml :as xml]))
+
+(def test-conf-filename "test-config.edn")
+
+(defn get-file-path
+  [fileset fname]
+  (try
+    (-> (-> fileset
+          (boot/tmp-get fname)
+          boot/tmp-dir)
+      (io/file fname)
+      .getPath)
+    (catch IllegalArgumentException e)))
+
+(defn write-config
+  [content fname fileset]
+  (if-let [f (get-file-path fileset fname)]
+    (spit f (with-out-str (pr content)))
+    (throw
+      (ex-info
+        (str "ERROR: failed to find file " fname " in boot's fileset.") {}))))
+
+(defn results-loc
+  [results-dir connector]
+  (let [rd (or results-dir ".")]
+    (if-not (s/blank? connector)
+      (str (io/file rd connector))
+      rd)))
+
+(defn xml-res-re
+  [junit-output-to]
+  (re-pattern (format "^%s.*\\.xml$" junit-output-to)))
+
+(defn is-xml-res-file
+  [f junit-output-to]
+  (re-find (xml-res-re junit-output-to) (:path f)))
+
+(defn find-res-xmls
+  [fileset junit-output-to]
+  (for [f (boot/output-files fileset) :when (is-xml-res-file f junit-output-to)]
+    (str (io/file (:dir f) (:path f)))))
+
+(defn copy-file [source-path dest-path]
+  (io/copy (io/file source-path) (io/file dest-path)))
+
+(defn mkdirs
+  [path]
+  (.mkdirs (io/file path)))
+
+(defn tag-matcher
+  [loc tagname]
+  (let [tag (:tag (zip/node loc))]
+    (= (keyword tagname) tag)))
+
+(defn match-testsuite?
+  [loc]
+  (tag-matcher loc "testsuite"))
+
+(defn match-testcase?
+  [loc]
+  (tag-matcher loc "testcase"))
+
+(defn attr-editor
+  [attr-name prep-val node]
+  (let [package-name (-> node :attrs attr-name)
+        new-content (assoc (:attrs node) attr-name (format "%s.%s" prep-val package-name))]
+    (assoc node :attrs new-content)))
+
+(defn package-editor
+  [prep-val node]
+  (attr-editor :package prep-val node))
+
+(defn classname-editor
+  [prep-val node]
+  (attr-editor :classname prep-val node))
+
+(defn tree-edit
+  "Take a zipper, a function that matches a pattern in the tree,
+   and a function that edits the current location in the tree.  Examine the tree
+   nodes in depth-first order, determine whether the matcher matches, and if so
+   apply the editor."
+  [zipper matcher editor]
+  (loop [loc zipper]
+    (if (zip/end? loc)
+      (zip/root loc)
+      (if-let [matcher-result (matcher loc)]
+        (let [new-loc (zip/edit loc editor)]
+          (if (not (= (zip/node new-loc) (zip/node loc)))
+            (recur (zip/next new-loc))))
+        (recur (zip/next loc))))))
+
+(defn update-test-meta
+  [filename cname]
+  (let [s (-> filename
+              slurp
+              xml/parse-str
+              zip/xml-zip
+              (tree-edit match-testsuite? (partial package-editor cname))
+              zip/xml-zip
+              (tree-edit match-testcase? (partial classname-editor cname))
+              xml/indent-str)]
+    (spit filename s)))
+
+(defn test-file-copy-update
+  [srcfn results-dir connector-name]
+  (let [dstfn (str (io/file results-dir (.getName (io/file srcfn))))]
+    (copy-file srcfn dstfn)
+    (if-not (empty? connector-name)
+      (update-test-meta dstfn connector-name))))
+
+(boot/deftask func-test-pre
+  "Run before SlipStream functional tests."
+  [_ serviceurl SERVICEURL str "SlipStream endpoint."
+   _ username USERNAME str "SlipStream username."
+   _ password PASSWORD str "SlipStream password."
+   _ app-uri APPURI str "Application URI (for deploying app and scaling)."
+   _ comp-name COMPNAME str "Component name (for scalable tests)."
+   _ comp-uri COMPURI str "Component URI (for deploying component)."
+   _ connector-name CONNECTOR str "Connector name."]
+  (fn middleware [next-task]
+      (fn handler [fileset]
+        (write-config *opts* test-conf-filename fileset)
+        (next-task fileset))))
+
+(boot/deftask func-test-post
+  "Run after SlipStream functional tests."
+  [_ results-dir RESULTSDIR str "Directory where to copy test results to."
+   _ connector-name CONNECTOR str "Connector name."
+   _ junit-output-to JUNITOUT str "The directory where a junit formatted report was generated."]
+  (fn middleware [next-task]
+    (fn handler [fileset]
+      (if-not (s/blank? results-dir)
+        (do
+          (mkdirs results-dir)
+          (doseq [fn (find-res-xmls fileset junit-output-to)]
+            (test-file-copy-update fn results-dir connector-name))))
+      (next-task fileset))))
+

--- a/clojure/test/sixsq/slipstream/authn_test.clj
+++ b/clojure/test/sixsq/slipstream/authn_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns sixsq.slipstream.authn-test
   (:require [clojure.test :refer :all]
             [clojure.test.junit :refer :all]

--- a/clojure/test/sixsq/slipstream/run_app_scale_test.clj
+++ b/clojure/test/sixsq/slipstream/run_app_scale_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns sixsq.slipstream.run-app-scale-test
   (:require [clojure.test :refer :all]
             [clojure.string :refer [starts-with?]]

--- a/clojure/test/sixsq/slipstream/run_app_test.clj
+++ b/clojure/test/sixsq/slipstream/run_app_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns sixsq.slipstream.run-app-test
   (:require [clojure.test :refer :all]
             [clojure.string :refer [starts-with?]]

--- a/clojure/test/sixsq/slipstream/run_comp_test.clj
+++ b/clojure/test/sixsq/slipstream/run_comp_test.clj
@@ -1,3 +1,17 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns sixsq.slipstream.run-comp-test
   (:require [clojure.test :refer :all]
             [clojure.string :refer [starts-with?]]

--- a/clojure/test/sixsq/slipstream/test_base.clj
+++ b/clojure/test/sixsq/slipstream/test_base.clj
@@ -1,3 +1,17 @@
+;; Copyright 2016, SixSq Sarl
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;; http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
 (ns sixsq.slipstream.test-base
   (:require
     [clojure.edn :as edn]


### PR DESCRIPTION
Boot task to simplify launching of functional tests.

- creates configuration file based on given parameters
- runs standard boot test
- copies resulting XML test results to a requested directory
- updates test names if `-c  / --connectors` parameter was given (by prepending connector name to test package and class names).

Example test

```
# ~/code/community/SlipStreamTests/clojure
boot func-test -n sixsq.slipstream.authn-test -u <user> -p <pass> -s https://nuv.la -c exoscale-ch-gva -c atos-es1 -j my-results -d ~/test-results/
...
# ls -R ~/test-results
atos-es1    exoscale-ch-gva

/Users/konstan/test-results/atos-es1:
sixsq.slipstream.authn-test.xml

/Users/konstan/test-results/exoscale-ch-gva:
sixsq.slipstream.authn-test.xml

# cat ~/test-results/exoscale-ch-gva/sixsq.slipstream.authn-test.xml
<?xml version="1.0" encoding="UTF-8"?><testsuites>
  <testsuite name="authn-test" package="exoscale-ch-gva.sixsq.slipstream">
    <testcase name="test-authn" classname="exoscale-ch-gva.sixsq.slipstream.authn-test"/>
  </testsuite>
</testsuites>
```
