### PR TITLE
Issue #7 no connector param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BOOT = boot
-BOOT_TEST = $(BOOT) --no-colors test
+BOOT_TEST = $(BOOT) --no-colors func-test
 
 all: clojure-test
 test: all
@@ -9,33 +9,27 @@ clojure-test-debug:
 
 clojure-test:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		  $(BOOT_TEST); }
+		$(BOOT_TEST)
 
 test-clojure-deps:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		   $(BOOT) show -d; }
+		$(BOOT) show -d
 
 test-auth:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		  $(BOOT_TEST) -n sixsq.slipstream.authn-test; }
+		$(BOOT_TEST) -n sixsq.slipstream.authn-test $(TESTOPTS)
 
 test-run-comp:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		  $(BOOT_TEST) -n sixsq.slipstream.run-comp-test; }
+		$(BOOT_TEST) -n sixsq.slipstream.run-comp-test $(TESTOPTS)
 
 test-run-app:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		  $(BOOT_TEST) -n sixsq.slipstream.run-app-test; }
+		$(BOOT_TEST) -n sixsq.slipstream.run-app-test $(TESTOPTS)
 
 test-run-app-scale:
 	cd clojure && \
-		{ export TIMBRE_NS_BLACKLIST='["kvlt.*"]'; \
-		  $(BOOT_TEST) -n sixsq.slipstream.run-app-scale-test; }
+	    $(BOOT_TEST) -n sixsq.slipstream.run-app-scale-test $(TESTOPTS)
 
 clean:
 	rm -rf clojure/target

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 # SlipStreamTests
 
 Check README files in the corresponding modules for how to configure and run the tests defined there.
+
+
+## Running tests with make
+
+For running functional tests with make
+
+```
+$ make <test-name> TESTOPTS=" --param value ..."  
+```
+
+where `<test-name>` is the name of the test as defined in Makefile. For example
+
+``` 
+$ make test-auth "TESTOPTS= -u user -p pass -s https://nuv.la -d ~/test-results"
+  ...
+$ make test-run-app-scale "TESTOPTS= -u user -p pass -s https://1.2.3.4 --insecure 
+   -c exoscale-ch-gva -c atos-es1 -d ~/test-results 
+   --app-uri examples/tutorials/service-testing/system 
+   --comp-uri testclient"
+  ...
+```
+
+The last command will run `run-app-scale` test (deploy application and scale up/down its named 
+component) on two clouds `exoscale-ch-gva` and `atos-es1`. It will use 
+`examples/tutorials/service-testing/system` application and will be scaling its `testclient` 
+component.  The results of the tests will be stored into `~/test-results` under
+`exoscale-ch-gva` and `atos-es1` sub-folders respectively.  The connections to the service will 
+be made in insecure mode (i.e., no checking of the server's authenticity will be made).
+
+For details on possible options to the functional tests run the following from project's 
+`clojure` sub-directory
+
+```
+$ boot func-test -h
+```
+

--- a/clojure/resources/test-config.edn
+++ b/clojure/resources/test-config.edn
@@ -1,8 +1,9 @@
 {
  :username "CHANGEME_USER"
  :password "CHANGEME_PASS"
- :serviceurl "CHANGEME_SERVICEURL"
+ :endpoint "CHANGEME_ENDPOINT"
  :app-uri "CHANGEME_APP_URI"
  :comp-name "CHANGEME_COMP_NAME"
  :connector-name "CHANGEME_CONNECTOR_NAME"
  }
+

--- a/clojure/src/sixsq/slipstream/func_tests.clj
+++ b/clojure/src/sixsq/slipstream/func_tests.clj
@@ -73,7 +73,7 @@
   prepending the connector name to the 'package' and 'classname' attributes.
   "
   [; func-test-pre
-   e endpoint ENDPOINT str "SlipStream endpoint"
+   s endpoint ENDPOINT str "SlipStream endpoint"
    u username USERNAME str "SlipStream username"
    p password PASSWORD str "SlipStream password"
    _ app-uri APPURI str "Application URI (for deploying app and scaling)"

--- a/clojure/src/sixsq/slipstream/func_tests.clj
+++ b/clojure/src/sixsq/slipstream/func_tests.clj
@@ -29,7 +29,7 @@
                          :app-uri (:app-uri opts)
                          :comp-name (:comp-name opts)
                          :comp-uri (:comp-uri opts)
-                         :insecure (:insecure opts)
+                         :insecure? (:insecure opts)
                          :connector-name connector)
        (btest/test :namespaces (:namespaces opts)
                    :exclusions (:exclusions opts)
@@ -73,7 +73,7 @@
   prepending the connector name to the 'package' and 'classname' attributes.
   "
   [; func-test-pre
-   s endpoint ENDPOINT str "SlipStream endpoint"
+   e endpoint ENDPOINT str "SlipStream endpoint"
    u username USERNAME str "SlipStream username"
    p password PASSWORD str "SlipStream password"
    _ app-uri APPURI str "Application URI (for deploying app and scaling)"

--- a/clojure/src/sixsq/slipstream/func_tests_impl.clj
+++ b/clojure/src/sixsq/slipstream/func_tests_impl.clj
@@ -137,7 +137,7 @@
 
 (boot/deftask func-test-pre
   "Run before SlipStream functional tests."
-  [_ serviceurl SERVICEURL str "SlipStream endpoint"
+  [_ endpoint ENDPOINT str "SlipStream endpoint"
    _ username USERNAME str "SlipStream username"
    _ password PASSWORD str "SlipStream password"
    _ app-uri APPURI str "Application URI (for deploying app and scaling)"

--- a/clojure/test/sixsq/slipstream/authn_test.clj
+++ b/clojure/test/sixsq/slipstream/authn_test.clj
@@ -24,13 +24,13 @@
 (def config (get-config))
 (def username (:username config))
 (def password (:password config))
-(def serviceurl (:serviceurl config))
+(def endpoint (:endpoint config))
 (def insecure (:insecure? config))
 
 ;; TODO: use cookie handling library to test content of cookie.
 (deftest test-authn
   (let [cookie (a/with-context {:insecure? insecure}
-                 (a/login! username password (a/to-login-url serviceurl)))]
+                 (a/login! username password (a/to-login-url endpoint)))]
     (is (not (nil? cookie)))
     (is (starts-with? cookie "com.sixsq.slipstream.cookie"))
     (is (.endsWith cookie "Path=/"))))

--- a/clojure/test/sixsq/slipstream/run_app_scale_test.clj
+++ b/clojure/test/sixsq/slipstream/run_app_scale_test.clj
@@ -29,7 +29,7 @@
 (def config (get-config))
 (def username (:username config))
 (def password (:password config))
-(def serviceurl (:serviceurl config))
+(def endpoint (:endpoint config))
 (def app-uri (:app-uri config))
 (def comp-name (:comp-name config))
 (def connector-name (:connector-name config))
@@ -49,7 +49,7 @@
 (deftest test-deploy-scale-terminate
 
   (testing "Authenticate: get and validate cookie."
-    (let [cookie (a/login! username password (a/to-login-url serviceurl))]
+    (let [cookie (a/login! username password (a/to-login-url endpoint))]
       (is (not (nil? cookie)))
       (is (starts-with? cookie "com.sixsq.slipstream.cookie"))
       (is (.endsWith cookie "Path=/"))))

--- a/clojure/test/sixsq/slipstream/run_app_test.clj
+++ b/clojure/test/sixsq/slipstream/run_app_test.clj
@@ -29,7 +29,7 @@
 (def config (get-config))
 (def username (:username config))
 (def password (:password config))
-(def serviceurl (:serviceurl config))
+(def endpoint (:endpoint config))
 (def comp-name (:comp-name config))
 (def app-uri (:app-uri config))
 (def connector-name (:connector-name config))
@@ -48,7 +48,7 @@
 (deftest test-deploy-terminate
 
   (testing "Authenticate: get and validate cookie."
-    (let [cookie (a/login! username password (a/to-login-url serviceurl))]
+    (let [cookie (a/login! username password (a/to-login-url endpoint))]
       (is (not (nil? cookie)))
       (is (starts-with? cookie "com.sixsq.slipstream.cookie"))
       (is (.endsWith cookie "Path=/"))))

--- a/clojure/test/sixsq/slipstream/run_comp_test.clj
+++ b/clojure/test/sixsq/slipstream/run_comp_test.clj
@@ -29,7 +29,7 @@
 (def config (get-config))
 (def username (:username config))
 (def password (:password config))
-(def serviceurl (:serviceurl config))
+(def endpoint (:endpoint config))
 (def comp-uri (:comp-uri config))
 (def connector-name (:connector-name config))
 (def insecure (:insecure? config))
@@ -47,7 +47,7 @@
 (deftest test-component-deploy-terminate
 
   (testing "Authenticate: get and validate cookie."
-    (let [cookie (a/login! username password (a/to-login-url serviceurl))]
+    (let [cookie (a/login! username password (a/to-login-url endpoint))]
       (is (not (nil? cookie)))
       (is (starts-with? cookie "com.sixsq.slipstream.cookie"))
       (is (.endsWith cookie "Path=/"))))

--- a/clojure/test/sixsq/slipstream/test_base.clj
+++ b/clojure/test/sixsq/slipstream/test_base.clj
@@ -88,3 +88,4 @@
   (f)
   (if-not (nil? *run-uuid*)
     (try (lr/terminate *run-uuid*) (catch Exception _))))
+


### PR DESCRIPTION
- fixed an issue when tests were not run at all if `--connectors` wasn't provided
- updated the logic around creation of final results directory
- added validation of `--connectors` and `--results-dir` parameters.  It should not be possible to provide multiple `-c` w/o `-d`.

Connected to #7 