### PR TITLE
added native validation of cookie and token

### DIFF
--- a/clojure/build.boot
+++ b/clojure/build.boot
@@ -24,6 +24,8 @@
                  '[[org.clojure/clojure]
                    [org.clojure/clojurescript]
 
+                   [clj-http "2.2.0"]
+                   [clj-jwt "0.1.1"]
                    [com.cemerick/url nil :scope "test"]
                    [com.sixsq.slipstream/SlipStreamClientAPI-jar :version :scope "test"]
 


### PR DESCRIPTION

Question: I was running the cookie validation (the old way) in every other test namespaces (e.g. https://github.com/slipstream/SlipStreamTests/blob/master/clojure/test/sixsq/slipstream/run_comp_test.clj#L49).  Should I remove that or include `authn-test` into that namespaces and run it each time?

Connected to #11 